### PR TITLE
Clean UTF-8 BOM parse errors from active Python files

### DIFF
--- a/software/__init__.py
+++ b/software/__init__.py
@@ -1,1 +1,1 @@
-﻿# WH1 staged software package.
+# WH1 staged software package.

--- a/software/adc/__init__.py
+++ b/software/adc/__init__.py
@@ -1,1 +1,1 @@
-﻿# MAX1238 ADC driver package.
+# MAX1238 ADC driver package.

--- a/software/common/__init__.py
+++ b/software/common/__init__.py
@@ -1,1 +1,1 @@
-﻿# Shared WH1 constants and helpers.
+# Shared WH1 constants and helpers.

--- a/software/common/hardware_map.py
+++ b/software/common/hardware_map.py
@@ -1,4 +1,4 @@
-﻿# Shared WH1 Rev A hardware constants.
+# Shared WH1 Rev A hardware constants.
 
 ADC_PART = "MAX1238EEE+"
 ADC_VREF = 4.096

--- a/software/diagnostics/__init__.py
+++ b/software/diagnostics/__init__.py
@@ -1,1 +1,1 @@
-﻿# Non-actuating diagnostics package.
+# Non-actuating diagnostics package.

--- a/software/power_monitoring/__init__.py
+++ b/software/power_monitoring/__init__.py
@@ -1,1 +1,1 @@
-﻿# ACS37800 power monitoring package.
+# ACS37800 power monitoring package.

--- a/software/rs485_cta2045/__init__.py
+++ b/software/rs485_cta2045/__init__.py
@@ -1,1 +1,1 @@
-﻿# RS-485 / CTA-2045 support package.
+# RS-485 / CTA-2045 support package.

--- a/software/valve_control/__init__.py
+++ b/software/valve_control/__init__.py
@@ -1,1 +1,1 @@
-﻿# Valve-control package. Use diagnostics/valve_gpio_check.py for first dry-run checks.
+# Valve-control package. Use diagnostics/valve_gpio_check.py for first dry-run checks.

--- a/software/water_draw/__init__.py
+++ b/software/water_draw/__init__.py
@@ -1,1 +1,1 @@
-﻿# Water draw control package.
+# Water draw control package.


### PR DESCRIPTION
## Summary
- Removed leading UTF-8 BOM / U+FEFF characters from active Python package/config files.
- No runtime logic changes.

## Verification
- Checked tracked Python/config files for UTF-8 BOM / U+FEFF characters.
- Verified no BOM / U+FEFF characters remain.
- Verified changed Python files parse with Python compile().
- Ran git diff --check.

Closes #102.