### PR TITLE
Harden valve boundary and controlled draw safety

### DIFF
--- a/software/runtime/controlled_water_draw_workflow.py
+++ b/software/runtime/controlled_water_draw_workflow.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-
-from software.sensors.sensor_reader import SensorReader
+from typing import Protocol
+from software.sensors.sensor_reader import SensorSnapshot
 from software.valve.valve_interface import Valve
 
 MAX_RUN_MINUTES = 5.0
@@ -13,11 +13,17 @@ MIN_FLOW_GPM = 0.05
 LOW_FLOW_TIMEOUT_S = 20.0
 PRINT_PERIOD_S = 0.5
 
+class SensorSnapshotReader(Protocol):
+    """Define the grouped sensor-read operation required by the draw workflow"""
+
+    def get_sensor_snapshot(self)->SensorSnapshot:
+        """Return one grouped termperature and flow snaphsot"""
+        ...
 
 def run_controlled_water_draw(
     target_volume_gal: float,
     *,
-    sensor_reader: SensorReader,
+    sensor_reader: SensorSnapshotReader,
     valve: Valve,
     max_run_minutes: float = MAX_RUN_MINUTES,
     monotonic: Callable[[], float] = time.monotonic,

--- a/software/runtime/controlled_water_draw_workflow.py
+++ b/software/runtime/controlled_water_draw_workflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from typing import Protocol
+
 from software.sensors.sensor_reader import SensorSnapshot
 from software.valve.valve_interface import Valve
 
@@ -13,12 +14,14 @@ MIN_FLOW_GPM = 0.05
 LOW_FLOW_TIMEOUT_S = 20.0
 PRINT_PERIOD_S = 0.5
 
+
 class SensorSnapshotReader(Protocol):
     """Define the grouped sensor-read operation required by the draw workflow"""
 
-    def get_sensor_snapshot(self)->SensorSnapshot:
-        """Return one grouped termperature and flow snaphsot"""
+    def get_sensor_snapshot(self) -> SensorSnapshot:
+        """Return one grouped temperature and flow snapshot"""
         ...
+
 
 def run_controlled_water_draw(
     target_volume_gal: float,
@@ -42,10 +45,10 @@ def run_controlled_water_draw(
     last_log = start
     low_flow_start: float | None = None
 
-    valve.open()
-    print("Valve command asserted")
-
     try:
+        valve.open()
+        print("Valve command asserted")
+
         while volume_gal < target_volume_gal:
             now = monotonic()
             elapsed_s = now - start

--- a/software/valve/gpio_valve_driver.py
+++ b/software/valve/gpio_valve_driver.py
@@ -6,30 +6,60 @@ from types import ModuleType
 
 
 class GpioValveDriver:
-    """Drive one valve-relay GPIO and return it LOW during cleanup."""
+    """Drive one valve-relay GPIO and safely manage its lifecycle"""
 
     def __init__(self, gpio: ModuleType, pin: int) -> None:
+        """Store the GPIO module and BCM pin used by the valve relay
+
+        Args:
+            gpio: Imported GPIO-compatible module
+            pin: BCM GPIO pin number controlling the valve relay
+
+        Safety:
+            The builder must intialize the output LOW before constructing this driver
+        """
         self._gpio = gpio
         self._pin = pin
-        self._closed = False
+        self._cleaned_up = False
+
+    def _require_active(self)->None:
+        """Reject GPIO commands after this driver has released its pin"""
+        if self._cleaned_up:
+            raise RuntimeError("valve GPIO drier has already been cleaned up")
 
     def open(self) -> None:
+        """Assert the relay output HIGH to command the valve open"""
+        self._require_active()
         self._gpio.output(self._pin, self._gpio.HIGH)
 
     def close(self) -> None:
+        """Return the relay output LOW to command the valve closed"""
+        self._require_active()
         self._gpio.output(self._pin, self._gpio.LOW)
 
     def cleanup(self) -> None:
-        if self._closed:
+        """Force the valve command LOW and release the GPIO pin once
+
+        Safety:
+            Cleanup is idempotent. Repeated calls do nothing. Once cleanup completes,
+            further open or close commands raise RuntimeError
+            """
+        if self._cleaned_up:
             return
+
         try:
             self.close()
         finally:
-            self._gpio.cleanup(self._pin)
-            self._closed = True
+            try:
+                self._gpio.cleanup(self._pin)
+            finally:
+                self._cleaned_up = True
 
     def __enter__(self) -> "GpioValveDriver":
+        """Return this activedriver for context-mamanger use"""
+        self._require_active()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Force LOW and release the GPIO pin when leaving the context"""
         self.cleanup()

--- a/tests/test_controlled_water_draw_workflow.py
+++ b/tests/test_controlled_water_draw_workflow.py
@@ -1,7 +1,7 @@
 """Laptop-safe tests for the controlled water-draw workflow."""
 
 import unittest
-from types import SimpleNamespace
+from software.sensors.sensor_reader import SensorSnapshot
 
 from software.runtime.controlled_water_draw_workflow import run_controlled_water_draw
 
@@ -23,13 +23,21 @@ class FakeReader:
         self._flow_gpm = flow_gpm
         self._error = error
 
-    def get_sensor_snapshot(self):
+    def get_sensor_snapshot(self)->SensorSnapshot:
         if self._error is not None:
             raise self._error
-        return SimpleNamespace(
+
+        return SensorSnapshot(
+            hot_raw_counts=0,
+            cold_raw_counts=0,
+            flow_raw_counts=0,
+            ambient_raw_counts=0,
             hot_temp_c=40.0,
+            hot_temp_f=104.0,
             cold_temp_c=20.0,
+            cold_temp_f=68.0,
             ambient_temp_c=22.0,
+            ambient_temp_f=71.6,
             flow_gpm=self._flow_gpm,
         )
 

--- a/tests/test_controlled_water_draw_workflow.py
+++ b/tests/test_controlled_water_draw_workflow.py
@@ -7,12 +7,15 @@ from software.runtime.controlled_water_draw_workflow import run_controlled_water
 
 
 class FakeValve:
-    def __init__(self) -> None:
+    def __init__(self, *, open_error: Exception | None = None) -> None:
         self.open_count = 0
         self.close_count = 0
+        self._open_error = open_error
 
     def open(self) -> None:
         self.open_count += 1
+        if self._open_error is not None:
+            raise self._open_error
 
     def close(self) -> None:
         self.close_count += 1
@@ -23,7 +26,7 @@ class FakeReader:
         self._flow_gpm = flow_gpm
         self._error = error
 
-    def get_sensor_snapshot(self)->SensorSnapshot:
+    def get_sensor_snapshot(self) -> SensorSnapshot:
         if self._error is not None:
             raise self._error
 
@@ -70,6 +73,20 @@ class ControlledWaterDrawWorkflowTest(unittest.TestCase):
                 valve=valve,
                 monotonic=lambda: next(times),
                 sleep=lambda _: None,
+            )
+
+        self.assertEqual(valve.open_count, 1)
+        self.assertEqual(valve.close_count, 1)
+
+    def test_closes_valve_when_open_raises(self) -> None:
+        """A failed open command still triggers exactly one close attempt."""
+        valve = FakeValve(open_error=RuntimeError("open failed"))
+
+        with self.assertRaisesRegex(RuntimeError, "open failed"):
+            run_controlled_water_draw(
+                1.0,
+                sensor_reader=FakeReader(),
+                valve=valve,
             )
 
         self.assertEqual(valve.open_count, 1)

--- a/tests/test_gpio_valve_driver.py
+++ b/tests/test_gpio_valve_driver.py
@@ -1,0 +1,80 @@
+"""Laptop-safe tests for the Raspberry Pi GPIO valve driver"""
+
+import unittest
+from types import ModuleType
+
+from software.valve.gpio_valve_driver import GpioValveDriver
+
+class FakeGpio(ModuleType):
+    """Record GPIO output and cleanup calls without touching real hardware"""
+
+    HIGH = 1
+    LOW = 0
+
+    def __init__(self)->None:
+        """Initialize an empty fake GPIO call history"""
+        super().__init__("fake_gpio")
+        self.output_calls: list[tuple[int, int]] = []
+        self.cleanup_calls: list[int] = []
+
+    def output(self, pin: int, state: int)->None:
+        """Record one requested GPIO output state"""
+        self.output_calls.append((pin, state))
+
+    def cleanup(self, pin: int)->None:
+        """Record cleanup of one GPIO pin"""
+        self.cleanup_calls.append(pin)
+
+
+class GpioValveDriverTest(unittest.TestCase):
+    """Verify valve GPIO commands and resource-lifecycle behavior"""
+
+    def setUp(self)->None:
+        """Create a fresh fake GPIO module and valve driver for each test"""
+        self.gpio = FakeGpio()
+        self.pin = 17
+        self.valve = GpioValveDriver(self.gpio, self.pin)
+
+    def test_open_writes_gpio_high(self)->None:
+        """Opening the valve should assert the relay output HIGH"""
+        self.valve.open()
+
+        self.assertEqual(self.gpio.output_calls, [(self.pin, self.gpio.HIGH)])
+
+    def test_close_writes_gpio_low(self)->None:
+        """Closing the valve should return the relay output to LOW"""
+        self.valve.close()
+
+        self.assertEqual(self.gpio.output_calls, [(self.pin, self.gpio.LOW)])
+
+    def test_cleanup_forces_low_and_releases_pin_once(self)->None:
+        """Cleanup should force LOW and remain safe when called repeatedly"""
+        self.valve.cleanup()
+        self.valve.cleanup()
+
+        self.assertEqual(self.gpio.output_calls, [(self.pin, self.gpio.LOW)])
+        self.assertEqual(self.gpio.cleanup_calls, [self.pin])
+
+    def test_open_afer_cleanup_raises_runtime_error(self)->None:
+        """A cleaned-up driver must not issue another GPIO HIGH command"""
+        self.valve.cleanup()
+        output_call_count = len(self.gpio.output_calls)
+
+        with self.assertRaises(RuntimeError):
+            self.valve.open()
+
+        self.assertEqual(len(self.gpio.output_calls), output_call_count)
+
+    def test_close_after_cleanup_raises_runtime_error(self)->None:
+        """A cleaned-up driver must not issue another GPIO LOW command"""
+        self.valve.cleanup()
+        output_call_count = len(self.gpio.output_calls)
+
+        with self.assertRaises(RuntimeError):
+            self.valve.close()
+
+        self.assertEqual(len(self.gpio.output_calls), output_call_count)
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Prevent GPIO valve commands after the driver has released its pin.
- Make GPIO cleanup idempotent and force the relay command LOW before cleanup.
- Add laptop-safe tests for valve open, close, cleanup, and post-cleanup rejection.
- Define the minimal sensor snapshot reader boundary required by the controlled water-draw workflow.
- Use real `SensorSnapshot` objects in workflow tests.
- Guarantee a valve close attempt when opening the valve raises an exception.

## Validation

- `24 passed, 2 subtests passed`
- `git diff --check` passed
- No Raspberry Pi hardware required for the new tests

## Safety behavior

- Physical valve close remains separate from GPIO resource cleanup.
- The workflow owns open/close behavior.
- The command and driver layers retain GPIO resource ownership.
- Dry-run-first operator behavior is unchanged.