### PR TITLE
Remove dry-run gates and harden valve resource ownership

### DIFF
--- a/DEPLOY_MANIFEST.md
+++ b/DEPLOY_MANIFEST.md
@@ -65,7 +65,7 @@ bin/valve-check
 bin/wh-draw --target-gal 0.1
 ```
 
-The last two commands are dry-run only unless `--enable-output` is supplied.
+The last two commands operate the validated valve and water-draw hardware.
 
 ## Controlled output commands
 
@@ -73,8 +73,8 @@ The completed valve, sensor, flow, temperature, and target-stop verification
 records permit controlled WH1 use:
 
 ```bash
-bin/valve-check --enable-output --state off
-bin/wh-draw --target-gal 0.1 --enable-output
+bin/valve-check --state off
+bin/wh-draw --target-gal 0.1
 ```
 
 ## Do not run

--- a/bin/README.md
+++ b/bin/README.md
@@ -24,4 +24,6 @@ Run from any directory, for example `bin/sensor-check`.
 
 ## Safety notes
 
-These wrappers can reach real hardware. Valve actuation and water draws require `--enable-output`; inspect GS10 serial-port arguments before use.
+These wrappers can reach real hardware. `valve-check` defaults to a controlled
+0.25-second open pulse, and `wh-draw` starts a controlled draw when given a
+valid target. Inspect GS10 serial-port arguments before use.

--- a/deployment/test_run_order/FIRST_PI_TEST_SEQUENCE.md
+++ b/deployment/test_run_order/FIRST_PI_TEST_SEQUENCE.md
@@ -65,24 +65,26 @@ Do not add ACS37800 register reads until the datasheet, active part variant, reg
 
 Record observed output in `test_records/`.
 
-## 5. Valve dry-run only
+## 5. Controlled valve pulse
 
 ```bash
 python3 bin/valve-check
 ```
 
-This must report dry-run behavior and must not touch GPIO17.
+This performs the default 0.25-second open pulse and then returns GPIO17 LOW.
 
 Record observed output in `test_records/`.
 
-## 6. Output checks only after review
-
-Do not run either command until relay polarity, wiring, load safety, fail-safe behavior, ADC values, flow scaling, and stop behavior are physically reviewed for the real station.
+## 6. Controlled output checks
 
 ```bash
-python3 bin/valve-check --enable-output --state off
-python3 bin/wh-draw --target-gal 0.1 --enable-output
+python3 bin/valve-check --state off
+python3 bin/wh-draw --target-gal 0.1
 ```
+
+The valve command above is close-only. The water-draw command constructs the
+station ADC and valve, runs one controlled 0.1-gallon draw, and releases both
+hardware resources.
 
 ## Reference records
 

--- a/software/commands/README.md
+++ b/software/commands/README.md
@@ -23,4 +23,4 @@ Prefer the matching `bin/` command. Python module form is `python3 -m software.c
 
 ## Safety notes
 
-Some commands open I2C or RS-485 devices or actuate GPIO. Read `--help`; valve and water-draw output require `--enable-output`.
+Some commands open I2C or RS-485 devices or actuate GPIO. Read `--help` before running a hardware command.

--- a/software/commands/check_valve_command.py
+++ b/software/commands/check_valve_command.py
@@ -1,4 +1,4 @@
-"""Command-line entrypoint for the dry-run-first valve diagnostic."""
+"""Command-line entrypoint for the WH1 valve diagnostic."""
 
 from __future__ import annotations
 
@@ -11,8 +11,7 @@ from software.valve.valve_diagnostic import MAX_PULSE_SECONDS, run_valve_diagnos
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Check the WH1 valve relay path.")
-    parser.add_argument("--enable-output", action="store_true")
-    parser.add_argument("--state", choices=("off", "on"), default="off")
+    parser.add_argument("--state", choices=("off", "on"), default="on")
     parser.add_argument("--pulse-seconds", type=float, default=0.25)
     args = parser.parse_args(argv)
     if not 0.0 <= args.pulse_seconds <= MAX_PULSE_SECONDS:
@@ -22,16 +21,27 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    valve = build_gpio_valve() if args.enable_output else None
+    valve = build_gpio_valve()
+    diagnostic_error: BaseException | None = None
     try:
         run_valve_diagnostic(
             valve=valve,
             requested_state=args.state,
             pulse_seconds=args.pulse_seconds,
         )
+    except BaseException as error:
+        diagnostic_error = error
+        raise
     finally:
         if valve is not None:
-            valve.cleanup()
+            try:
+                valve.cleanup()
+            except BaseException as cleanup_error:
+                if diagnostic_error is None:
+                    raise
+                diagnostic_error.add_note(
+                    f"Valve cleanup also failed: {cleanup_error!r}"
+                )
     return 0
 
 

--- a/software/commands/run_water_draw_command.py
+++ b/software/commands/run_water_draw_command.py
@@ -18,11 +18,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run one controlled WH1 water draw")
     parser.add_argument("--target-gal", type=float, required=True)
     parser.add_argument("--max-run-minutes", type=float, default=MAX_RUN_MINUTES)
-    parser.add_argument(
-        "--enable-output",
-        action="store_true",
-        help="open station hardware; dry-run by default",
-    )
     return parser.parse_args(argv)
 
 
@@ -33,14 +28,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.max_run_minutes <= 0.0:
         raise SystemExit("--max-run-minutes must be greater than zero")
 
-    if not args.enable_output:
-        print(f"Target: {args.target_gal:.3f} gal")
-        print("[DRY-RUN] Valve output is disabled.")
-        print("No ADC bus was opened and no GPIO output was configured.")
-        return 0
-
     adc = build_max1238()
     valve = None
+    workflow_error: BaseException | None = None
     try:
         valve = build_gpio_valve()
         run_controlled_water_draw(
@@ -49,10 +39,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             valve=valve,
             max_run_minutes=args.max_run_minutes,
         )
+    except BaseException as error:
+        workflow_error = error
+        raise
     finally:
-        if valve is not None:
-            valve.cleanup()
-        adc.close()
+        cleanup_error = workflow_error
+        try:
+            if valve is not None:
+                valve.cleanup()
+        except BaseException as valve_cleanup_error:
+            if cleanup_error is None:
+                cleanup_error = valve_cleanup_error
+            else:
+                cleanup_error.add_note(
+                    f"Valve cleanup also failed: {valve_cleanup_error!r}"
+                )
+
+        try:
+            adc.close()
+        except BaseException as adc_close_error:
+            if cleanup_error is None:
+                cleanup_error = adc_close_error
+            else:
+                cleanup_error.add_note(
+                    f"ADC close also failed: {adc_close_error!r}"
+                )
+
+        if workflow_error is None and cleanup_error is not None:
+            raise cleanup_error
     return 0
 
 

--- a/software/runtime/controlled_water_draw_workflow.py
+++ b/software/runtime/controlled_water_draw_workflow.py
@@ -45,6 +45,7 @@ def run_controlled_water_draw(
     last_log = start
     low_flow_start: float | None = None
 
+    workflow_error: BaseException | None = None
     try:
         valve.open()
         print("Valve command asserted")
@@ -92,9 +93,19 @@ def run_controlled_water_draw(
                 last_log = now
 
             sleep(0.05)
+    except BaseException as error:
+        workflow_error = error
+        raise
     finally:
-        valve.close()
-        print("Valve command cleared")
+        try:
+            valve.close()
+            print("Valve command cleared")
+        except BaseException as close_error:
+            if workflow_error is None:
+                raise
+            workflow_error.add_note(
+                f"Valve close also failed: {close_error!r}"
+            )
 
     print(f"Volume drawn: {volume_gal:.3f} gal")
     return volume_gal

--- a/software/valve/README.md
+++ b/software/valve/README.md
@@ -9,7 +9,7 @@ WH1 valve requirements, direct GPIO control, safe construction, and diagnostic b
 - `valve_interface.py`: operations required by workflows.
 - `gpio_valve_driver.py`: direct GPIO relay control.
 - `gpio_valve_builder.py`: safe LOW-first driver construction.
-- `valve_diagnostic.py`: dry-run-first valve check behavior.
+- `valve_diagnostic.py`: controlled valve pulse and close-only check behavior.
 
 ## Does not belong here
 
@@ -25,4 +25,5 @@ Import the interface in workflows. Operators run `bin/valve-check`.
 
 ## Safety notes
 
-The builder and driver can actuate GPIO17 and the connected valve. `bin/valve-check` is dry-run unless `--enable-output` is supplied.
+The builder and driver actuate GPIO17 and the connected valve. `bin/valve-check`
+defaults to a 0.25-second open pulse; use `--state off` for a close-only command.

--- a/software/valve/gpio_valve_driver.py
+++ b/software/valve/gpio_valve_driver.py
@@ -20,12 +20,13 @@ class GpioValveDriver:
         """
         self._gpio = gpio
         self._pin = pin
-        self._cleaned_up = False
+        self._commands_disabled = False
+        self._cleanup_complete = False
 
     def _require_active(self)->None:
-        """Reject GPIO commands after this driver has released its pin"""
-        if self._cleaned_up:
-            raise RuntimeError("valve GPIO drier has already been cleaned up")
+        """Reject valve commands after resource cleanup has begun"""
+        if self._commands_disabled:
+            raise RuntimeError("valve GPIO driver cleanup has already begun")
 
     def open(self) -> None:
         """Assert the relay output HIGH to command the valve open"""
@@ -41,22 +42,36 @@ class GpioValveDriver:
         """Force the valve command LOW and release the GPIO pin once
 
         Safety:
-            Cleanup is idempotent. Repeated calls do nothing. Once cleanup completes,
-            further open or close commands raise RuntimeError
+            The first call permanently disables normal valve commands. GPIO release
+            may be retried after failure, and repeated successful calls do nothing.
             """
-        if self._cleaned_up:
+        if self._cleanup_complete:
             return
 
-        try:
-            self.close()
-        finally:
+        close_error: BaseException | None = None
+        if not self._commands_disabled:
+            self._commands_disabled = True
             try:
-                self._gpio.cleanup(self._pin)
-            finally:
-                self._cleaned_up = True
+                self._gpio.output(self._pin, self._gpio.LOW)
+            except BaseException as error:
+                close_error = error
+
+        try:
+            self._gpio.cleanup(self._pin)
+        except BaseException as cleanup_error:
+            if close_error is None:
+                raise
+            close_error.add_note(
+                f"GPIO pin cleanup also failed: {cleanup_error!r}"
+            )
+            raise close_error from cleanup_error
+
+        self._cleanup_complete = True
+        if close_error is not None:
+            raise close_error
 
     def __enter__(self) -> "GpioValveDriver":
-        """Return this activedriver for context-mamanger use"""
+        """Return this active driver for context-manager use"""
         self._require_active()
         return self
 

--- a/software/valve/valve_diagnostic.py
+++ b/software/valve/valve_diagnostic.py
@@ -13,22 +13,18 @@ MAX_PULSE_SECONDS = 5.0
 
 def run_valve_diagnostic(
     *,
-    valve: Valve | None,
+    valve: Valve,
     requested_state: str,
     pulse_seconds: float,
     sleep: Callable[[float], None] = time.sleep,
 ) -> None:
-    """Report a dry run or safely exercise an injected valve."""
+    """Exercise an injected valve and restore its physical closed state."""
     if requested_state not in {"off", "on"}:
         raise ValueError("requested_state must be 'off' or 'on'")
     if not 0.0 <= pulse_seconds <= MAX_PULSE_SECONDS:
         raise ValueError("pulse_seconds must be between 0 and 5 seconds")
 
-    if valve is None:
-        print(f"[DRY-RUN] GPIO{VALVE_PIN} would be requested {requested_state.upper()}.")
-        print("No GPIO library was imported and no output was configured.")
-        return
-
+    diagnostic_error: BaseException | None = None
     try:
         if requested_state == "on":
             valve.open()
@@ -36,6 +32,16 @@ def run_valve_diagnostic(
             sleep(pulse_seconds)
         else:
             print(f"GPIO{VALVE_PIN} LOW requested")
+    except BaseException as error:
+        diagnostic_error = error
+        raise
     finally:
-        valve.close()
-        print(f"GPIO{VALVE_PIN} LOW")
+        try:
+            valve.close()
+            print(f"GPIO{VALVE_PIN} LOW")
+        except BaseException as close_error:
+            if diagnostic_error is None:
+                raise
+            diagnostic_error.add_note(
+                f"Valve close also failed: {close_error!r}"
+            )

--- a/tests/test_check_valve_command.py
+++ b/tests/test_check_valve_command.py
@@ -1,0 +1,111 @@
+"""Laptop-safe tests for valve diagnostic command resource ownership."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock, patch
+
+from software.commands import check_valve_command
+from software.valve.valve_diagnostic import run_valve_diagnostic
+
+
+class CheckValveCommandTest(unittest.TestCase):
+    """Verify default actuation and command-owned driver cleanup."""
+
+    def test_no_arguments_constructs_valve_and_runs_default_open_pulse(self) -> None:
+        """Open for 0.25 seconds, physically close, then clean the driver."""
+        valve = Mock()
+        pulse_delays_s: list[float] = []
+
+        def exercise_diagnostic(
+            *,
+            valve: object,
+            requested_state: str,
+            pulse_seconds: float,
+        ) -> None:
+            """Run the real diagnostic with an injected no-wait pulse timer."""
+            run_valve_diagnostic(
+                valve=valve,
+                requested_state=requested_state,
+                pulse_seconds=pulse_seconds,
+                sleep=pulse_delays_s.append,
+            )
+
+        with (
+            patch.object(
+                check_valve_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ) as build_valve,
+            patch.object(
+                check_valve_command,
+                "run_valve_diagnostic",
+                side_effect=exercise_diagnostic,
+            ) as diagnostic,
+        ):
+            result = check_valve_command.main([])
+
+        self.assertEqual(result, 0)
+        build_valve.assert_called_once_with()
+        diagnostic.assert_called_once_with(
+            valve=valve,
+            requested_state="on",
+            pulse_seconds=0.25,
+        )
+        valve.open.assert_called_once_with()
+        valve.close.assert_called_once_with()
+        self.assertEqual(pulse_delays_s, [0.25])
+        valve.cleanup.assert_called_once_with()
+
+    def test_cleans_owned_driver_when_diagnostic_raises(self) -> None:
+        """Clean the constructed driver when diagnostic execution fails."""
+        valve = Mock()
+        diagnostic_error = RuntimeError("diagnostic failed")
+
+        with (
+            patch.object(
+                check_valve_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(
+                check_valve_command,
+                "run_valve_diagnostic",
+                side_effect=diagnostic_error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                check_valve_command.main([])
+
+        self.assertIs(raised.exception, diagnostic_error)
+        valve.cleanup.assert_called_once_with()
+
+    def test_diagnostic_error_survives_cleanup_failure(self) -> None:
+        """Preserve diagnostic failure and record a later cleanup failure."""
+        valve = Mock()
+        diagnostic_error = RuntimeError("diagnostic failed")
+        cleanup_error = RuntimeError("cleanup failed")
+        valve.cleanup.side_effect = cleanup_error
+
+        with (
+            patch.object(
+                check_valve_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(
+                check_valve_command,
+                "run_valve_diagnostic",
+                side_effect=diagnostic_error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                check_valve_command.main([])
+
+        self.assertIs(raised.exception, diagnostic_error)
+        self.assertIn(repr(cleanup_error), diagnostic_error.__notes__[0])
+        valve.cleanup.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controlled_water_draw_workflow.py
+++ b/tests/test_controlled_water_draw_workflow.py
@@ -7,18 +7,31 @@ from software.runtime.controlled_water_draw_workflow import run_controlled_water
 
 
 class FakeValve:
-    def __init__(self, *, open_error: Exception | None = None) -> None:
+    """Record physical valve commands and inject representative failures."""
+
+    def __init__(
+        self,
+        *,
+        open_error: Exception | None = None,
+        close_error: Exception | None = None,
+    ) -> None:
+        """Initialize command counts and optional open or close failures."""
         self.open_count = 0
         self.close_count = 0
         self._open_error = open_error
+        self._close_error = close_error
 
     def open(self) -> None:
+        """Record an open command and optionally raise its configured error."""
         self.open_count += 1
         if self._open_error is not None:
             raise self._open_error
 
     def close(self) -> None:
+        """Record a close command and optionally raise its configured error."""
         self.close_count += 1
+        if self._close_error is not None:
+            raise self._close_error
 
 
 class FakeReader:
@@ -90,6 +103,29 @@ class ControlledWaterDrawWorkflowTest(unittest.TestCase):
             )
 
         self.assertEqual(valve.open_count, 1)
+        self.assertEqual(valve.close_count, 1)
+
+    def test_sensor_error_survives_valve_close_failure(self) -> None:
+        """Preserve the sensor error and record a later physical close failure."""
+        sensor_error = RuntimeError("read failed")
+        close_error = RuntimeError("close failed")
+        valve = FakeValve(close_error=close_error)
+        times = iter((0.0, 0.1))
+
+        with self.assertRaises(RuntimeError) as raised:
+            run_controlled_water_draw(
+                1.0,
+                sensor_reader=FakeReader(error=sensor_error),
+                valve=valve,
+                monotonic=lambda: next(times),
+                sleep=lambda _: None,
+            )
+
+        self.assertIs(raised.exception, sensor_error)
+        self.assertEqual(
+            sensor_error.__notes__,
+            [f"Valve close also failed: {close_error!r}"],
+        )
         self.assertEqual(valve.close_count, 1)
 
 

--- a/tests/test_gpio_valve_builder.py
+++ b/tests/test_gpio_valve_builder.py
@@ -1,0 +1,84 @@
+"""Laptop-safe tests for GPIO valve construction and initial state."""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from software.valve import gpio_valve_builder
+from software.valve.gpio_valve_driver import GpioValveDriver
+
+
+class FakeGpioModule(types.ModuleType):
+    """Record GPIO configuration without importing Raspberry Pi hardware."""
+
+    BCM = 11
+    OUT = 1
+    LOW = 0
+    HIGH = 1
+
+    def __init__(self) -> None:
+        """Initialize empty GPIO configuration and output histories."""
+        super().__init__("RPi.GPIO")
+        self.warning_states: list[bool] = []
+        self.mode_calls: list[int] = []
+        self.setup_calls: list[tuple[int, int, int]] = []
+        self.output_calls: list[tuple[int, int]] = []
+        self.cleanup_calls: list[int] = []
+
+    def setwarnings(self, enabled: bool) -> None:
+        """Record whether GPIO warnings were enabled."""
+        self.warning_states.append(enabled)
+
+    def setmode(self, mode: int) -> None:
+        """Record the selected GPIO numbering mode."""
+        self.mode_calls.append(mode)
+
+    def setup(self, pin: int, mode: int, *, initial: int) -> None:
+        """Record output-pin setup and its initial state."""
+        self.setup_calls.append((pin, mode, initial))
+
+    def output(self, pin: int, state: int) -> None:
+        """Record a valve output request."""
+        self.output_calls.append((pin, state))
+
+    def cleanup(self, pin: int) -> None:
+        """Record release of one GPIO pin."""
+        self.cleanup_calls.append(pin)
+
+
+def make_fake_rpi_modules(
+    gpio_module: FakeGpioModule,
+) -> dict[str, types.ModuleType]:
+    """Create import-compatible fake ``RPi`` and ``RPi.GPIO`` modules."""
+    rpi_module = types.ModuleType("RPi")
+    rpi_module.GPIO = gpio_module
+    return {"RPi": rpi_module, "RPi.GPIO": gpio_module}
+
+
+class GpioValveBuilderTest(unittest.TestCase):
+    """Verify lazy, safe GPIO setup and driver dependency ownership."""
+
+    def test_builder_configures_requested_pin_low_and_returns_driver(self) -> None:
+        """Configure BCM output LOW and retain the same GPIO module and pin."""
+        fake_gpio = FakeGpioModule()
+        requested_pin = 23
+
+        with patch.dict(sys.modules, make_fake_rpi_modules(fake_gpio)):
+            valve = gpio_valve_builder.build_gpio_valve(pin=requested_pin)
+
+        self.assertIsInstance(valve, GpioValveDriver)
+        self.assertIs(valve._gpio, fake_gpio)
+        self.assertEqual(valve._pin, requested_pin)
+        self.assertEqual(fake_gpio.warning_states, [False])
+        self.assertEqual(fake_gpio.mode_calls, [fake_gpio.BCM])
+        self.assertEqual(
+            fake_gpio.setup_calls,
+            [(requested_pin, fake_gpio.OUT, fake_gpio.LOW)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpio_valve_driver.py
+++ b/tests/test_gpio_valve_driver.py
@@ -75,6 +75,94 @@ class GpioValveDriverTest(unittest.TestCase):
 
         self.assertEqual(len(self.gpio.output_calls), output_call_count)
 
+    def test_cleanup_failure_leaves_driver_retryable(self) -> None:
+        """Retry GPIO release without issuing another physical LOW command."""
+        cleanup_error = RuntimeError("GPIO cleanup failed")
+        original_cleanup = self.gpio.cleanup
+        cleanup_attempts = 0
+
+        def fail_first_cleanup(pin: int) -> None:
+            """Fail the first release attempt and record a later successful one."""
+            nonlocal cleanup_attempts
+            cleanup_attempts += 1
+            if cleanup_attempts == 1:
+                raise cleanup_error
+            original_cleanup(pin)
+
+        self.gpio.cleanup = fail_first_cleanup
+
+        with self.assertRaises(RuntimeError) as raised:
+            self.valve.cleanup()
+        self.valve.cleanup()
+
+        self.assertIs(raised.exception, cleanup_error)
+        self.assertEqual(cleanup_attempts, 2)
+        self.assertEqual(
+            self.gpio.output_calls,
+            [(self.pin, self.gpio.LOW)],
+        )
+        self.assertEqual(self.gpio.cleanup_calls, [self.pin])
+        self.assertTrue(self.valve._commands_disabled)
+        self.assertTrue(self.valve._cleanup_complete)
+
+    def test_cleanup_failure_disables_open_and_close(self) -> None:
+        """Reject later commands without issuing additional GPIO writes."""
+        cleanup_error = RuntimeError("GPIO cleanup failed")
+
+        def fail_cleanup(pin: int) -> None:
+            """Raise the configured GPIO release failure."""
+            raise cleanup_error
+
+        self.gpio.cleanup = fail_cleanup
+
+        with self.assertRaises(RuntimeError):
+            self.valve.cleanup()
+
+        output_calls_after_cleanup = list(self.gpio.output_calls)
+        with self.assertRaises(RuntimeError):
+            self.valve.open()
+        with self.assertRaises(RuntimeError):
+            self.valve.close()
+
+        self.assertEqual(
+            output_calls_after_cleanup,
+            [(self.pin, self.gpio.LOW)],
+        )
+        self.assertEqual(self.gpio.output_calls, output_calls_after_cleanup)
+        self.assertTrue(self.valve._commands_disabled)
+        self.assertFalse(self.valve._cleanup_complete)
+
+    def test_close_error_survives_gpio_cleanup_failure(self) -> None:
+        """Preserve LOW-output failure while recording pin-release failure."""
+        close_error = RuntimeError("LOW output failed")
+        cleanup_error = RuntimeError("GPIO cleanup failed")
+        output_attempts = 0
+
+        def fail_output(pin: int, state: int) -> None:
+            """Raise the configured LOW-output failure."""
+            nonlocal output_attempts
+            output_attempts += 1
+            raise close_error
+
+        def fail_cleanup(pin: int) -> None:
+            """Raise the configured GPIO pin-release failure."""
+            raise cleanup_error
+
+        self.gpio.output = fail_output
+        self.gpio.cleanup = fail_cleanup
+
+        with self.assertRaises(RuntimeError) as raised:
+            self.valve.cleanup()
+
+        self.assertIs(raised.exception, close_error)
+        self.assertEqual(
+            close_error.__notes__,
+            [f"GPIO pin cleanup also failed: {cleanup_error!r}"],
+        )
+        self.assertEqual(output_attempts, 1)
+        self.assertTrue(self.valve._commands_disabled)
+        self.assertFalse(self.valve._cleanup_complete)
+
 
 if __name__=="__main__":
     unittest.main()

--- a/tests/test_run_water_draw_command.py
+++ b/tests/test_run_water_draw_command.py
@@ -1,0 +1,224 @@
+"""Laptop-safe tests for controlled water-draw command ownership."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock, patch
+
+from software.commands import run_water_draw_command
+
+
+class RunWaterDrawCommandTest(unittest.TestCase):
+    """Verify dependency construction and command-owned cleanup."""
+
+    def test_valid_target_constructs_resources_and_cleans_in_order(self) -> None:
+        """Construct real dependencies, then release valve before ADC."""
+        events: list[str] = []
+        adc = Mock()
+        valve = Mock()
+        adc.close.side_effect = lambda: events.append("adc.close")
+        valve.cleanup.side_effect = lambda: events.append("valve.cleanup")
+
+        with (
+            patch.object(
+                run_water_draw_command,
+                "build_max1238",
+                return_value=adc,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "SensorReader",
+                side_effect=lambda built_adc: ("reader", built_adc),
+            ),
+            patch.object(
+                run_water_draw_command,
+                "run_controlled_water_draw",
+            ) as workflow,
+        ):
+            result = run_water_draw_command.main(
+                [
+                    "--target-gal",
+                    "2.5",
+                    "--max-run-minutes",
+                    "3",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        workflow.assert_called_once_with(
+            2.5,
+            sensor_reader=("reader", adc),
+            valve=valve,
+            max_run_minutes=3.0,
+        )
+        valve.open.assert_not_called()
+        valve.close.assert_not_called()
+        self.assertEqual(events, ["valve.cleanup", "adc.close"])
+
+    def test_workflow_failure_attempts_both_resource_cleanups(self) -> None:
+        """Clean the valve and ADC when the controlled workflow raises."""
+        events: list[str] = []
+        adc = Mock()
+        valve = Mock()
+        workflow_error = RuntimeError("workflow failed")
+        valve.cleanup.side_effect = lambda: events.append("valve.cleanup")
+        adc.close.side_effect = lambda: events.append("adc.close")
+
+        with (
+            patch.object(
+                run_water_draw_command,
+                "build_max1238",
+                return_value=adc,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(run_water_draw_command, "SensorReader"),
+            patch.object(
+                run_water_draw_command,
+                "run_controlled_water_draw",
+                side_effect=workflow_error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                run_water_draw_command.main(["--target-gal", "1"])
+
+        self.assertIs(raised.exception, workflow_error)
+        self.assertEqual(events, ["valve.cleanup", "adc.close"])
+
+    def test_adc_close_is_attempted_when_valve_cleanup_raises(self) -> None:
+        """Preserve valve cleanup failure while still attempting ADC closure."""
+        adc = Mock()
+        valve = Mock()
+        cleanup_error = RuntimeError("valve cleanup failed")
+        valve.cleanup.side_effect = cleanup_error
+
+        with (
+            patch.object(
+                run_water_draw_command,
+                "build_max1238",
+                return_value=adc,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(run_water_draw_command, "SensorReader"),
+            patch.object(run_water_draw_command, "run_controlled_water_draw"),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                run_water_draw_command.main(["--target-gal", "1"])
+
+        self.assertIs(raised.exception, cleanup_error)
+        adc.close.assert_called_once_with()
+
+    def test_valve_build_failure_closes_constructed_adc(self) -> None:
+        """Close the ADC if valve construction fails after ADC construction."""
+        adc = Mock()
+        build_error = RuntimeError("valve build failed")
+
+        with (
+            patch.object(
+                run_water_draw_command,
+                "build_max1238",
+                return_value=adc,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "build_gpio_valve",
+                side_effect=build_error,
+            ),
+            patch.object(run_water_draw_command, "run_controlled_water_draw") as workflow,
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                run_water_draw_command.main(["--target-gal", "1"])
+
+        self.assertIs(raised.exception, build_error)
+        workflow.assert_not_called()
+        adc.close.assert_called_once_with()
+
+    def test_workflow_error_survives_both_cleanup_failures(self) -> None:
+        """Preserve workflow failure and record both later release failures."""
+        adc = Mock()
+        valve = Mock()
+        workflow_error = RuntimeError("workflow failed")
+        valve_cleanup_error = RuntimeError("valve cleanup failed")
+        adc_close_error = RuntimeError("ADC close failed")
+        valve.cleanup.side_effect = valve_cleanup_error
+        adc.close.side_effect = adc_close_error
+
+        with (
+            patch.object(
+                run_water_draw_command,
+                "build_max1238",
+                return_value=adc,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(run_water_draw_command, "SensorReader"),
+            patch.object(
+                run_water_draw_command,
+                "run_controlled_water_draw",
+                side_effect=workflow_error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                run_water_draw_command.main(["--target-gal", "1"])
+
+        self.assertIs(raised.exception, workflow_error)
+        self.assertEqual(
+            workflow_error.__notes__,
+            [
+                f"Valve cleanup also failed: {valve_cleanup_error!r}",
+                f"ADC close also failed: {adc_close_error!r}",
+            ],
+        )
+        valve.cleanup.assert_called_once_with()
+        adc.close.assert_called_once_with()
+
+    def test_valve_cleanup_error_survives_adc_close_failure(self) -> None:
+        """Preserve the first release failure while recording ADC close failure."""
+        adc = Mock()
+        valve = Mock()
+        valve_cleanup_error = RuntimeError("valve cleanup failed")
+        adc_close_error = RuntimeError("ADC close failed")
+        valve.cleanup.side_effect = valve_cleanup_error
+        adc.close.side_effect = adc_close_error
+
+        with (
+            patch.object(
+                run_water_draw_command,
+                "build_max1238",
+                return_value=adc,
+            ),
+            patch.object(
+                run_water_draw_command,
+                "build_gpio_valve",
+                return_value=valve,
+            ),
+            patch.object(run_water_draw_command, "SensorReader"),
+            patch.object(run_water_draw_command, "run_controlled_water_draw"),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                run_water_draw_command.main(["--target-gal", "1"])
+
+        self.assertIs(raised.exception, valve_cleanup_error)
+        self.assertEqual(
+            valve_cleanup_error.__notes__,
+            [f"ADC close also failed: {adc_close_error!r}"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_valve_diagnostic.py
+++ b/tests/test_valve_diagnostic.py
@@ -1,0 +1,77 @@
+"""Tests for enabled-output valve diagnostic exception handling."""
+
+from __future__ import annotations
+
+import unittest
+
+from software.valve.valve_diagnostic import run_valve_diagnostic
+
+
+class FakeValve:
+    """Record diagnostic valve commands and inject close failures."""
+
+    def __init__(self, *, close_error: Exception | None = None) -> None:
+        """Initialize command counts and an optional close failure."""
+        self.open_count = 0
+        self.close_count = 0
+        self._close_error = close_error
+
+    def open(self) -> None:
+        """Record one physical valve-open command."""
+        self.open_count += 1
+
+    def close(self) -> None:
+        """Record one physical close command and optionally raise."""
+        self.close_count += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+
+class ValveDiagnosticTest(unittest.TestCase):
+    """Verify diagnostic errors remain primary when physical close fails."""
+
+    def test_off_state_closes_without_opening_or_sleeping(self) -> None:
+        """Keep the close-only operator command available without a pulse."""
+        valve = FakeValve()
+        sleep_delays_s: list[float] = []
+
+        run_valve_diagnostic(
+            valve=valve,
+            requested_state="off",
+            pulse_seconds=0.25,
+            sleep=sleep_delays_s.append,
+        )
+
+        self.assertEqual(valve.open_count, 0)
+        self.assertEqual(valve.close_count, 1)
+        self.assertEqual(sleep_delays_s, [])
+
+    def test_pulse_error_survives_valve_close_failure(self) -> None:
+        """Preserve pulse failure and record a later physical close failure."""
+        pulse_error = RuntimeError("pulse failed")
+        close_error = RuntimeError("close failed")
+        valve = FakeValve(close_error=close_error)
+
+        def fail_sleep(delay_s: float) -> None:
+            """Raise the configured pulse failure."""
+            raise pulse_error
+
+        with self.assertRaises(RuntimeError) as raised:
+            run_valve_diagnostic(
+                valve=valve,
+                requested_state="on",
+                pulse_seconds=0.25,
+                sleep=fail_sleep,
+            )
+
+        self.assertIs(raised.exception, pulse_error)
+        self.assertEqual(
+            pulse_error.__notes__,
+            [f"Valve close also failed: {close_error!r}"],
+        )
+        self.assertEqual(valve.open_count, 1)
+        self.assertEqual(valve.close_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Remove the obsolete `--enable-output` requirement from valve checks and controlled water draws.
- Make `bin/valve-check` perform a real 0.25-second open/close pulse by default.
- Keep `--state off` available for a close-only valve command.
- Make `bin/wh-draw --target-gal ...` execute the real hardware workflow directly.
- Remove the nullable dry-run path from the valve diagnostic.
- Verify the GPIO builder initializes the relay output LOW.
- Harden valve and ADC resource cleanup while preserving primary operational errors.
- Separate disabled valve commands from completed GPIO release so failed cleanup remains retryable without allowing further actuation.
- Update active operator documentation to match the verified live-hardware workflow.

## Validation

- Focused valve and command tests passed.
- Full suite: `40 passed, 2 subtests passed`
- `git diff --check` passed
- Active-folder scan found no remaining `--enable-output`, `DRY-RUN`, or dry-run references.

## Ownership behavior

- Diagnostics and workflows own physical valve open/close behavior.
- Commands own GPIO driver cleanup and ADC close.
- Valve and ADC release are both attempted during failure handling.
- Cleanup errors are retained without replacing the primary workflow or diagnostic failure.
- Valve commands remain disabled after cleanup begins, while failed GPIO release may be retried.